### PR TITLE
Use HTTPS repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A PostCSS plugin to rename css selector",
   "main": "index.js",
   "types": "index.d.ts",
-  "repository": "git@github.com:noyobo/postcss-selector-rename.git",
+  "repository": "git+https://github.com/noyobo/postcss-selector-rename.git",
   "author": "noyobo<noyobo@gmail.com>",
   "keywords": [
     "postcss-plugin",


### PR DESCRIPTION
## Summary

- Update the package repository metadata to use the canonical HTTPS GitHub URL.
- Keep the repository target unchanged: `noyobo/postcss-selector-rename`.

## Why

The current `git@github.com:` repository URL requires SSH handling. The HTTPS form is easier for package consumers, scanners, and registry tooling to resolve without SSH configuration.

## Validation

- `node -e "const p=require('./package.json'); if (p.repository !== 'git+https://github.com/noyobo/postcss-selector-rename.git') throw new Error(p.repository); console.log(p.repository)"`
- `git diff --check`
- `git ls-remote https://github.com/noyobo/postcss-selector-rename.git HEAD`
- `yarn install --frozen-lockfile --ignore-scripts`
- `yarn test`
- `npm pack --dry-run`
